### PR TITLE
chore/w2-devops-compose-flyway-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+      TESTCONTAINERS_CHECKS_DISABLE: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,4 +27,4 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Verify (unit + integration)
-        run: ./gradlew check --no-daemon
+        run: ./gradlew check --no-daemon --stacktrace

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ For design decisions, see: `docs/adr/0001-observability-baseline.md`.
 
 ## Demo (curl)
 
+**Windows PowerShell note:** `curl` is an alias for `Invoke-WebRequest`. Use `curl.exe` or `Invoke-RestMethod` instead.
+
 ### 1) Healthcheck
 ```bash
 curl -i http://localhost:8080/actuator/health
@@ -140,6 +142,32 @@ On Windows PowerShell, `cp` works as well.
 
 ---
 
+## DB & migrations (Flyway)
+
+EventHub uses **Flyway** for schema migrations.
+
+### How migrations run
+- On application startup (profiles `docker` and `dev`), Flyway validates and applies pending migrations from:
+  - `src/main/resources/db/migration/`
+- Migration history is tracked in `flyway_schema_history`.
+
+### Reset DB (start from scratch)
+This will remove containers **and** delete the Postgres volume (all data):
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
+### Verify migrations / tables
+
+```bash
+docker compose exec db psql -U eventhub -d eventhub -c "select * from flyway_schema_history order by installed_rank;"
+docker compose exec db psql -U eventhub -d eventhub -c "\dt"
+```
+
+---
+
 ### Local dev (recommended): PostgreSQL in Docker + API on host (dev profile)
 
 ```bash
@@ -165,7 +193,7 @@ docker compose exec db psql -U eventhub -d eventhub -c "select id, title, starts
 
 ### Full Docker (API + DB)
 ```bash
-docker compose --profile full up -d --build
+docker compose up -d --build
 docker compose logs -f api
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       retries: 10
 
   api:
-    profiles: ["full"]
     build:
       context: .
       dockerfile: Dockerfile
@@ -31,7 +30,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health | grep -q UP"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health > /dev/null"]
       interval: 10s
       timeout: 5s
       retries: 15

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,5 +1,7 @@
 # Runbook (host + compose)
 
+**Windows PowerShell note:** `curl` is an alias for `Invoke-WebRequest`. Use `curl.exe` or `Invoke-RestMethod`.
+
 Goal: verify end-to-end (Swagger/curl) and prove Flyway-managed persistence.
 DoD: step-by-step commands documented + DB verification queries.
 
@@ -43,17 +45,17 @@ curl -s -X POST http://localhost:8080/api/v1/events \
 		"endsAt": "2030-01-01T11:00:00Z"
 	}'
 
-# Copy the "id" from the JSON response and set it here
-export EVENT_ID="<id>"
+# Copy the "id" from the JSON response and reuse it in the next commands:
+# <id>
 
 # List
 curl -fsS -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events
 
 # Get by id
-curl -fsS -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/$EVENT_ID
+curl -fsS -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/<id>
 
 # Update
-curl -s -X PUT http://localhost:8080/api/v1/events/$EVENT_ID \
+curl -s -X PUT http://localhost:8080/api/v1/events/<id> \
 	-H "Content-Type: application/json" \
 	-H "X-Correlation-Id: demo-123" \
 	-d '{
@@ -63,24 +65,22 @@ curl -s -X PUT http://localhost:8080/api/v1/events/$EVENT_ID \
 	}'
 
 # Delete
-curl -i -X DELETE -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/$EVENT_ID
+curl -i -X DELETE -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/<id>
 ```
 
 ---
 
 ## B) All Docker (API + DB via Compose)
 
-The _api_ service is under _profiles: ["full"]_.
-
 ```bash
-docker compose --profile full up -d --build
+docker compose up -d --build
 docker compose logs -f api
 ```
 
 Smoke:
 
 ```bash
-curl -fsS http://localhost:8080/actuator/health
+curl.exe -fsS http://localhost:8080/actuator/health
 ```
 
 ---

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -46,16 +46,13 @@ curl -s -X POST http://localhost:8080/api/v1/events \
 	}'
 
 # Copy the "id" from the JSON response and reuse it in the next commands:
-# <id>
-
-# List
-curl -fsS -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events
+# {id}
 
 # Get by id
-curl -fsS -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/<id>
+curl -fsS -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/{id}
 
 # Update
-curl -s -X PUT http://localhost:8080/api/v1/events/<id> \
+curl -s -X PUT http://localhost:8080/api/v1/events/{id} \
 	-H "Content-Type: application/json" \
 	-H "X-Correlation-Id: demo-123" \
 	-d '{
@@ -65,7 +62,7 @@ curl -s -X PUT http://localhost:8080/api/v1/events/<id> \
 	}'
 
 # Delete
-curl -i -X DELETE -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/<id>
+curl -i -X DELETE -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events/{id}
 ```
 
 ---


### PR DESCRIPTION
### **User description**
# Summary
Harden local DevOps workflow for EventHub by making Docker Compose reproducible from scratch (DB + API), validating startup order via healthchecks, and aligning CI to run the full Gradle verification suite. Also improved repo docs (README + runbook) so reviewers can reproduce Flyway-managed persistence and smoke tests quickly.

# Scope
- **Area:** DevOps / CI / Docs
- **Type:** chore / docs
- **Related issue(s):** N/A

# Changes
## Architecture / Design
- Docker Compose now supports two local workflows:
  - **Default:** DB in Docker + API in Docker (full stack)
  - **Alternative:** DB in Docker + API on host (dev profile) documented in README/runbook
- Added/verified service healthchecks and startup ordering (`depends_on: condition: service_healthy`) for stable boot.

## API Contract (if applicable)
- **Endpoint(s):**
	- `GET /actuator/health` → `200`
	- (Existing) `* /api/v1/events/*` → unchanged
- **Behavior changes:**
	- None (no API contract change). Only infrastructure + docs + CI.

## Validation & Error Handling (if applicable)
- **400** when:
	- N/A (unchanged)
- **404** when:
	- N/A (unchanged)
- **409** when:
	- N/A (unchanged)

## Persistence / Data (if applicable)
- Verified Flyway execution on container startup (`V1__create_events_table.sql`)
- Confirmed `flyway_schema_history` is created and populated after clean boot
- DB reset workflow documented (`docker compose down -v`)

# Root Cause (if bugfix)
- **Observed:** Local compose workflow was inconsistent / unclear for reviewers (profiles usage + container logs + repeatable boot + Flyway proof).
- **Cause:** Missing/unclear documentation and a compose setup that encouraged “it works on my machine” runs.
- **Fix:** Standardize compose entrypoint (db + api), add healthchecks/startup ordering, document runbook steps, and enforce CI with `./gradlew check`.

# How to Test
## Local
1. `docker compose down -v`
2. `docker compose up --build`
3. Smoke:
	- `curl.exe -fsS http://localhost:8080/actuator/health`
4. Verify Flyway history:
	- `docker compose exec db psql -U eventhub -d eventhub -c "select installed_rank, version, description, script, success from flyway_schema_history order by installed_rank;"`
5. (Optional) Check tables:
	- `docker compose exec db psql -U eventhub -d eventhub -c "\dt"`

## Automated Tests
- [ ] Unit:
	- `./gradlew test`
- [ ] Integration:
	- `./gradlew integrationTest`
- [ ] Full verify:
	- `./gradlew check`

# Screenshots (attach)
- [ ] Compose boot logs (db healthy + api started with profile docker)
- [ ] `GET /actuator/health` = UP
- [ ] `flyway_schema_history` row showing V1 applied

# Definition of Done
- [x] Endpoints respond with correct statuses (200/201/204 + 400/404; 409 only for real conflicts)
- [x] Validation messages are clear and consistent
- [x] Error payload format is consistent across the API
- [x] Swagger/OpenAPI is accessible locally
- [x] Clean layers: domain/application/infrastructure/presentation remain separated

# Notes / Follow-ups
- Consider adding a short “Troubleshooting Windows” section (PowerShell curl alias, ports in use, Docker Desktop) to docs/runbook.md.
- Optional future hardening: pin Postgres image patch version and add `README` quickstart for “DB only + host API” vs “full compose”.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Removed API service profile requirement; now starts by default with DB

- Simplified healthcheck logic and improved startup ordering with service dependencies

- Pinned CI runner to ubuntu-24.04 and added Gradle stacktrace for better debugging

- Added comprehensive DB & migrations documentation with Flyway reset/verification steps

- Updated runbook with Windows PowerShell curl notes and simplified compose commands


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Pin CI runner and improve Gradle debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Pinned runner to ubuntu-24.04 for consistency<br> <li> Added TestContainers environment variables to disable Ryuk and checks<br> <li> Added --stacktrace flag to Gradle check for better error visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/Deviitt11/eventhub-api/pull/9/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add Flyway documentation and Windows curl notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added Windows PowerShell curl alias warning in demo section<br> <li> Added new "DB & migrations (Flyway)" section with migration workflow <br>explanation<br> <li> Documented DB reset procedure and verification queries for migrations <br>and tables<br> <li> Removed --profile full flag from full Docker compose command (now <br>default)</ul>


</details>


  </td>
  <td><a href="https://github.com/Deviitt11/eventhub-api/pull/9/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runbook.md</strong><dd><code>Align runbook with default compose and Windows guidance</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/runbook.md

<ul><li>Added Windows PowerShell curl alias warning at top of document<br> <li> Removed --profile full flag from compose commands (now default)<br> <li> Simplified EVENT_ID variable usage to inline <id> placeholder<br> <li> Changed curl to curl.exe in smoke test for Windows compatibility<br> <li> Removed redundant explanation about api service profiles</ul>


</details>


  </td>
  <td><a href="https://github.com/Deviitt11/eventhub-api/pull/9/files#diff-bba543a809d32babfc0199f7b0431b8bdd8d9948c6df1613f4aaafc83c6a4072">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Make API service default and simplify healthchecks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Removed profiles: ["full"] from api service to make it start by <br>default<br> <li> Simplified api healthcheck from grep-based to null redirect check<br> <li> Maintained service_healthy dependency condition for proper startup <br>ordering</ul>


</details>


  </td>
  <td><a href="https://github.com/Deviitt11/eventhub-api/pull/9/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to CI configuration, Docker Compose wiring/healthchecks, and documentation; no application/runtime business logic is modified. Main risk is CI or local-dev flakiness if Testcontainers or the updated healthcheck behavior differs across environments.
> 
> **Overview**
> Improves reproducibility and debuggability of the dev workflow by making `docker compose up` start both DB and API by default (removes the `full` profile), tightening startup ordering via `depends_on: condition: service_healthy`, and simplifying the API healthcheck to a plain `/actuator/health` probe.
> 
> Updates GitHub Actions to run on `ubuntu-24.04`, disables Testcontainers Ryuk/checks via env vars, and adds Gradle `--stacktrace` to `./gradlew check` for easier CI failure diagnosis.
> 
> Expands docs (`README.md`, `docs/runbook.md`) with Flyway migration/reset/verification steps and Windows PowerShell `curl` guidance, and aligns examples to the new Compose commands and `{id}` placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c656b2c793ee9a2e48a15b360e854a61dcf2021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->