### PR TITLE
feat/events-list-query-hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,24 @@
 - No API contract changes
 - No persistence changes
 - No Flyway migrations
+
+### Thursday — Backend Advanced / Events Query Hardening
+
+#### Shipped
+- Added explicit default sorting to `GET /api/v1/events` by `startsAt`
+- Added optional `startsAt`-based filters to the events list endpoint
+- Hardened invalid query parameter handling for `GET /api/v1/events`
+- Updated API documentation to reflect the supported list query parameters
+- Added/updated tests to cover list ordering, filtering, and invalid query scenarios
+
+#### Impact
+- More predictable and interview-grade list endpoint behavior
+- Better support for real client use cases when querying events by time
+- Stronger and more consistent error handling for malformed list queries
+- Improved API discoverability through updated Swagger/OpenAPI docs
+
+#### No change
+- No new endpoints introduced
+- No persistence schema changes
+- No Flyway migrations
+- No large refactor across layers

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ curl -i -H "X-Correlation-Id: demo-123" http://localhost:8080/api/v1/events
 curl -i http://localhost:8080/api/v1/events
 ```
 
+List events with optional filters:
+```bash
+curl -i "http://localhost:8080/api/v1/events?startsAtFrom=2030-01-01T09:00:00Z&startsAtTo=2030-01-01T18:00:00Z"
+```
+
+If a filter is malformed or `startsAtFrom` is after `startsAtTo`, the API returns the standard `400` error payload.
+
 ### 4) Minimal E2E (create → fetch → delete)
 ```bash
 # create

--- a/src/integrationTest/java/dev/codedbydavid/eventhub/presentation/event/EventControllerIT.java
+++ b/src/integrationTest/java/dev/codedbydavid/eventhub/presentation/event/EventControllerIT.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.not;
 
@@ -399,6 +400,30 @@ class EventControllerIT {
         assertThat(filteredTitles).containsExactly(
                 "Boundary Event Start " + uniqueSuffix,
                 "Boundary Event End " + uniqueSuffix);
+    }
+
+    @Test
+    void list_events_with_malformed_query_param_returns_400_standard_payload() throws Exception {
+        mockMvc.perform(get("/api/v1/events")
+                        .param("startsAtFrom", "not-a-date"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.details", containsString("startsAtFrom")))
+                .andExpect(jsonPath("$.details", containsString("Expected ISO-8601 date-time")))
+                .andExpect(jsonPath("$.path").value("/api/v1/events"));
+    }
+
+    @Test
+    void list_events_with_invalid_range_returns_400_standard_payload() throws Exception {
+        mockMvc.perform(get("/api/v1/events")
+                        .param("startsAtFrom", "2034-01-01T12:00:00Z")
+                        .param("startsAtTo", "2034-01-01T10:00:00Z"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("DOMAIN_VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("Event validation failed"))
+                .andExpect(jsonPath("$.details").value("startsAtFrom must be before or equal to startsAtTo"))
+                .andExpect(jsonPath("$.path").value("/api/v1/events"));
     }
 
     @Test

--- a/src/integrationTest/java/dev/codedbydavid/eventhub/presentation/event/EventControllerIT.java
+++ b/src/integrationTest/java/dev/codedbydavid/eventhub/presentation/event/EventControllerIT.java
@@ -29,6 +29,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -270,6 +271,38 @@ class EventControllerIT {
     }
 
     @Test
+    void list_events_returns_events_sorted_by_startsAt_ascending_with_stable_tie_breaker() throws Exception {
+        String uniqueSuffix = UUID.randomUUID().toString();
+
+        createEvent("Ordered Event Late " + uniqueSuffix,
+                Instant.parse("2030-06-01T12:00:00Z"),
+                Instant.parse("2030-06-01T13:00:00Z"));
+        createEvent("Ordered Event Early " + uniqueSuffix,
+                Instant.parse("2030-06-01T09:00:00Z"),
+                Instant.parse("2030-06-01T10:00:00Z"));
+        createEvent("Ordered Event Middle " + uniqueSuffix,
+                Instant.parse("2030-06-01T10:30:00Z"),
+                Instant.parse("2030-06-01T11:30:00Z"));
+
+        String responseBody = mockMvc.perform(get("/api/v1/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode events = objectMapper.readTree(responseBody);
+        List<String> orderedTitles = events.findValuesAsText("title").stream()
+                .filter(title -> title.endsWith(uniqueSuffix))
+                .toList();
+
+        assertThat(orderedTitles).containsExactly(
+                "Ordered Event Early " + uniqueSuffix,
+                "Ordered Event Middle " + uniqueSuffix,
+                "Ordered Event Late " + uniqueSuffix);
+    }
+
+    @Test
     void update_to_collide_with_existing_event_returns_409_conflict() throws Exception {
         Instant startsAtA = Instant.now().plusSeconds(3600);
         Instant endsAtA = startsAtA.plusSeconds(3600);
@@ -328,6 +361,21 @@ class EventControllerIT {
                 .andExpect(jsonPath("$.message").value("Resource conflict"))
                 .andExpect(jsonPath("$.details").isNotEmpty())
                 .andExpect(jsonPath("$.path").value("/api/v1/events/" + idB));
+    }
+
+    private void createEvent(String title, Instant startsAt, Instant endsAt) throws Exception {
+        String json = """
+		{
+			"title": "%s",
+			"startsAt": "%s",
+			"endsAt": "%s"
+		}
+		""".formatted(title, startsAt.toString(), endsAt.toString());
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated());
     }
 
 	/*

--- a/src/integrationTest/java/dev/codedbydavid/eventhub/presentation/event/EventControllerIT.java
+++ b/src/integrationTest/java/dev/codedbydavid/eventhub/presentation/event/EventControllerIT.java
@@ -303,6 +303,105 @@ class EventControllerIT {
     }
 
     @Test
+    void list_events_without_filters_keeps_default_ordering_and_returns_all_matching_test_events() throws Exception {
+        String uniqueSuffix = UUID.randomUUID().toString();
+
+        createEvent("No Filter Event Late " + uniqueSuffix,
+                Instant.parse("2031-07-01T12:00:00Z"),
+                Instant.parse("2031-07-01T13:00:00Z"));
+        createEvent("No Filter Event Early " + uniqueSuffix,
+                Instant.parse("2031-07-01T09:00:00Z"),
+                Instant.parse("2031-07-01T10:00:00Z"));
+        createEvent("No Filter Event Boundary " + uniqueSuffix,
+                Instant.parse("2031-07-01T10:00:00Z"),
+                Instant.parse("2031-07-01T11:00:00Z"));
+
+        String responseBody = mockMvc.perform(get("/api/v1/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode events = objectMapper.readTree(responseBody);
+        List<String> orderedTitles = events.findValuesAsText("title").stream()
+                .filter(title -> title.endsWith(uniqueSuffix))
+                .toList();
+
+        assertThat(orderedTitles).containsExactly(
+                "No Filter Event Early " + uniqueSuffix,
+                "No Filter Event Boundary " + uniqueSuffix,
+                "No Filter Event Late " + uniqueSuffix);
+    }
+
+    @Test
+    void list_events_with_startsAt_filters_reduces_results() throws Exception {
+        String uniqueSuffix = UUID.randomUUID().toString();
+
+        createEvent("Filtered Event Early " + uniqueSuffix,
+                Instant.parse("2032-08-01T08:00:00Z"),
+                Instant.parse("2032-08-01T09:00:00Z"));
+        createEvent("Filtered Event Match " + uniqueSuffix,
+                Instant.parse("2032-08-01T10:00:00Z"),
+                Instant.parse("2032-08-01T11:00:00Z"));
+        createEvent("Filtered Event Late " + uniqueSuffix,
+                Instant.parse("2032-08-01T12:00:00Z"),
+                Instant.parse("2032-08-01T13:00:00Z"));
+
+        String responseBody = mockMvc.perform(get("/api/v1/events")
+                        .param("startsAtFrom", "2032-08-01T09:30:00Z")
+                        .param("startsAtTo", "2032-08-01T10:30:00Z"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode events = objectMapper.readTree(responseBody);
+        List<String> filteredTitles = events.findValuesAsText("title").stream()
+                .filter(title -> title.endsWith(uniqueSuffix))
+                .toList();
+
+        assertThat(filteredTitles).containsExactly("Filtered Event Match " + uniqueSuffix);
+    }
+
+    @Test
+    void list_events_with_inclusive_startsAt_limits_includes_boundary_values() throws Exception {
+        String uniqueSuffix = UUID.randomUUID().toString();
+
+        createEvent("Boundary Event Before " + uniqueSuffix,
+                Instant.parse("2033-09-01T09:59:59Z"),
+                Instant.parse("2033-09-01T10:30:00Z"));
+        createEvent("Boundary Event Start " + uniqueSuffix,
+                Instant.parse("2033-09-01T10:00:00Z"),
+                Instant.parse("2033-09-01T11:00:00Z"));
+        createEvent("Boundary Event End " + uniqueSuffix,
+                Instant.parse("2033-09-01T11:00:00Z"),
+                Instant.parse("2033-09-01T12:00:00Z"));
+        createEvent("Boundary Event After " + uniqueSuffix,
+                Instant.parse("2033-09-01T11:00:01Z"),
+                Instant.parse("2033-09-01T12:30:00Z"));
+
+        String responseBody = mockMvc.perform(get("/api/v1/events")
+                        .param("startsAtFrom", "2033-09-01T10:00:00Z")
+                        .param("startsAtTo", "2033-09-01T11:00:00Z"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode events = objectMapper.readTree(responseBody);
+        List<String> filteredTitles = events.findValuesAsText("title").stream()
+                .filter(title -> title.endsWith(uniqueSuffix))
+                .toList();
+
+        assertThat(filteredTitles).containsExactly(
+                "Boundary Event Start " + uniqueSuffix,
+                "Boundary Event End " + uniqueSuffix);
+    }
+
+    @Test
     void update_to_collide_with_existing_event_returns_409_conflict() throws Exception {
         Instant startsAtA = Instant.now().plusSeconds(3600);
         Instant endsAtA = startsAtA.plusSeconds(3600);

--- a/src/main/java/dev/codedbydavid/eventhub/application/event/ListEventsUseCase.java
+++ b/src/main/java/dev/codedbydavid/eventhub/application/event/ListEventsUseCase.java
@@ -4,6 +4,7 @@ import dev.codedbydavid.eventhub.domain.event.Event;
 import dev.codedbydavid.eventhub.domain.event.EventRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -16,6 +17,10 @@ public class ListEventsUseCase {
 
     public List<Event> execute() {
         return eventRepository.findAll();
+    }
+
+    public List<Event> execute(LocalDateTime startsAtFrom, LocalDateTime startsAtTo) {
+        return eventRepository.findAll(startsAtFrom, startsAtTo);
     }
 }
 

--- a/src/main/java/dev/codedbydavid/eventhub/domain/event/EventRepository.java
+++ b/src/main/java/dev/codedbydavid/eventhub/domain/event/EventRepository.java
@@ -1,5 +1,6 @@
 package dev.codedbydavid.eventhub.domain.event;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,6 +11,8 @@ public interface EventRepository {
     Optional<Event> findById(UUID id);
     
     List<Event> findAll();
+
+    List<Event> findAll(LocalDateTime startsAtFrom, LocalDateTime startsAtTo);
     
     void deleteById(UUID id);
 }

--- a/src/main/java/dev/codedbydavid/eventhub/infrastructure/config/OpenApiConfig.java
+++ b/src/main/java/dev/codedbydavid/eventhub/infrastructure/config/OpenApiConfig.java
@@ -20,8 +20,14 @@ public class OpenApiConfig {
             }
 
             openApi.getPaths().forEach((path, item) -> {
-                for (Operation op : item.readOperations()) {
+                if ("/api/v1/events".equals(path) && item.getGet() != null) {
+                    addListEventsQueryParameter(item.getGet(), "startsAtFrom",
+                            "Inclusive lower bound for event start time in ISO-8601 UTC format.");
+                    addListEventsQueryParameter(item.getGet(), "startsAtTo",
+                            "Inclusive upper bound for event start time in ISO-8601 UTC format.");
+                }
 
+                for (Operation op : item.readOperations()) {
                     boolean alreadyPresent = op.getParameters() != null
                             && op.getParameters().stream().anyMatch(p ->
                             "header".equalsIgnoreCase(p.getIn())
@@ -43,5 +49,28 @@ public class OpenApiConfig {
                 }
             });
         };
+    }
+
+    private void addListEventsQueryParameter(Operation op, String name, String description) {
+        boolean alreadyPresent = op.getParameters() != null
+                && op.getParameters().stream().anyMatch(p ->
+                "query".equalsIgnoreCase(p.getIn())
+                        && name.equalsIgnoreCase(p.getName())
+        );
+
+        if (alreadyPresent) {
+            return;
+        }
+
+        Parameter queryParameter = new Parameter()
+                .in("query")
+                .name(name)
+                .description(description)
+                .required(false)
+                .schema(new StringSchema()
+                        .format("date-time")
+                        .example("2030-01-01T10:00:00Z"));
+
+        op.addParametersItem(queryParameter);
     }
 }

--- a/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventJpaRepository.java
+++ b/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventJpaRepository.java
@@ -3,11 +3,15 @@ package dev.codedbydavid.eventhub.infrastructure.persistence.event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface EventJpaRepository extends JpaRepository<EventJpaEntity, UUID> {
     List<EventJpaEntity> findAllByOrderByStartsAtAscIdAsc();
+    List<EventJpaEntity> findAllByStartsAtGreaterThanEqualOrderByStartsAtAscIdAsc(LocalDateTime startsAtFrom);
+    List<EventJpaEntity> findAllByStartsAtLessThanEqualOrderByStartsAtAscIdAsc(LocalDateTime startsAtTo);
+    List<EventJpaEntity> findAllByStartsAtBetweenOrderByStartsAtAscIdAsc(LocalDateTime startsAtFrom, LocalDateTime startsAtTo);
 }
 

--- a/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventJpaRepository.java
+++ b/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventJpaRepository.java
@@ -3,9 +3,11 @@ package dev.codedbydavid.eventhub.infrastructure.persistence.event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface EventJpaRepository extends JpaRepository<EventJpaEntity, UUID> {
+    List<EventJpaEntity> findAllByOrderByStartsAtAscIdAsc();
 }
 

--- a/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventRepositoryAdapter.java
+++ b/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventRepositoryAdapter.java
@@ -51,7 +51,7 @@ public class EventRepositoryAdapter implements EventRepository {
 
     @Override
     public List<Event> findAll() {
-        return jpaRepository.findAll().stream()
+        return jpaRepository.findAllByOrderByStartsAtAscIdAsc().stream()
                 .map(this::toDomainEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventRepositoryAdapter.java
+++ b/src/main/java/dev/codedbydavid/eventhub/infrastructure/persistence/event/EventRepositoryAdapter.java
@@ -5,6 +5,7 @@ import dev.codedbydavid.eventhub.domain.event.EventNotFoundException;
 import dev.codedbydavid.eventhub.domain.event.EventRepository;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,6 +53,29 @@ public class EventRepositoryAdapter implements EventRepository {
     @Override
     public List<Event> findAll() {
         return jpaRepository.findAllByOrderByStartsAtAscIdAsc().stream()
+                .map(this::toDomainEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Event> findAll(LocalDateTime startsAtFrom, LocalDateTime startsAtTo) {
+        if (startsAtFrom == null && startsAtTo == null) {
+            return findAll();
+        }
+
+        if (startsAtFrom == null) {
+            return jpaRepository.findAllByStartsAtLessThanEqualOrderByStartsAtAscIdAsc(startsAtTo).stream()
+                    .map(this::toDomainEntity)
+                    .collect(Collectors.toList());
+        }
+
+        if (startsAtTo == null) {
+            return jpaRepository.findAllByStartsAtGreaterThanEqualOrderByStartsAtAscIdAsc(startsAtFrom).stream()
+                    .map(this::toDomainEntity)
+                    .collect(Collectors.toList());
+        }
+
+        return jpaRepository.findAllByStartsAtBetweenOrderByStartsAtAscIdAsc(startsAtFrom, startsAtTo).stream()
                 .map(this::toDomainEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/dev/codedbydavid/eventhub/presentation/event/EventController.java
+++ b/src/main/java/dev/codedbydavid/eventhub/presentation/event/EventController.java
@@ -6,9 +6,14 @@ import dev.codedbydavid.eventhub.application.event.GetEventUseCase;
 import dev.codedbydavid.eventhub.application.event.ListEventsUseCase;
 import dev.codedbydavid.eventhub.application.event.UpdateEventUseCase;
 import dev.codedbydavid.eventhub.domain.event.Event;
+import dev.codedbydavid.eventhub.domain.event.EventValidationException;
 import dev.codedbydavid.eventhub.presentation.event.dto.CreateEventRequest;
 import dev.codedbydavid.eventhub.presentation.event.dto.EventResponse;
 import dev.codedbydavid.eventhub.presentation.event.dto.UpdateEventRequest;
+import dev.codedbydavid.eventhub.presentation.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -81,11 +86,15 @@ public class EventController {
         }
 
         @Operation(summary = "List all events")
-        @ApiResponse(responseCode = "200", description = "List of events")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "List of events", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventResponse.class)))),
+                        @ApiResponse(responseCode = "400", description = "Invalid query parameters", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        })
         @GetMapping
         public ResponseEntity<List<EventResponse>> listEvents(
                         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) java.time.Instant startsAtFrom,
                         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) java.time.Instant startsAtTo) {
+                validateStartsAtRange(startsAtFrom, startsAtTo);
                 List<Event> events = listEventsUseCase.execute(
                                 startsAtFrom != null ? LocalDateTime.ofInstant(startsAtFrom, ZoneOffset.UTC) : null,
                                 startsAtTo != null ? LocalDateTime.ofInstant(startsAtTo, ZoneOffset.UTC) : null);
@@ -135,5 +144,11 @@ public class EventController {
                                 event.getEndsAt(),
                                 event.getCreatedAt(),
                                 event.getUpdatedAt());
+        }
+
+        private void validateStartsAtRange(java.time.Instant startsAtFrom, java.time.Instant startsAtTo) {
+                if (startsAtFrom != null && startsAtTo != null && startsAtFrom.isAfter(startsAtTo)) {
+                        throw new EventValidationException("startsAtFrom must be before or equal to startsAtTo");
+                }
         }
 }

--- a/src/main/java/dev/codedbydavid/eventhub/presentation/event/EventController.java
+++ b/src/main/java/dev/codedbydavid/eventhub/presentation/event/EventController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -82,8 +83,12 @@ public class EventController {
         @Operation(summary = "List all events")
         @ApiResponse(responseCode = "200", description = "List of events")
         @GetMapping
-        public ResponseEntity<List<EventResponse>> listEvents() {
-                List<Event> events = listEventsUseCase.execute();
+        public ResponseEntity<List<EventResponse>> listEvents(
+                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) java.time.Instant startsAtFrom,
+                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) java.time.Instant startsAtTo) {
+                List<Event> events = listEventsUseCase.execute(
+                                startsAtFrom != null ? LocalDateTime.ofInstant(startsAtFrom, ZoneOffset.UTC) : null,
+                                startsAtTo != null ? LocalDateTime.ofInstant(startsAtTo, ZoneOffset.UTC) : null);
                 List<EventResponse> responses = events.stream()
                                 .map(this::toResponse)
                                 .collect(Collectors.toList());

--- a/src/main/java/dev/codedbydavid/eventhub/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/codedbydavid/eventhub/presentation/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.Instant;
 import java.util.stream.Collectors;
@@ -78,6 +79,30 @@ public class GlobalExceptionHandler {
                 ErrorResponse errorResponse = new ErrorResponse(
                                 "VALIDATION_ERROR",
                                 "Constraint validation failed",
+                                details,
+                                Instant.now(),
+                                request.getRequestURI());
+
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        }
+
+        @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+        public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+                        MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+                String parameterName = ex.getName();
+                Object rejectedValue = ex.getValue();
+                String details = "%s: invalid value '%s'. Expected ISO-8601 date-time (e.g., 2030-01-01T10:00:00Z)"
+                                .formatted(parameterName, rejectedValue);
+
+                log.warn("Invalid request parameter for {} {}: {}={}",
+                                request.getMethod(),
+                                request.getRequestURI(),
+                                parameterName,
+                                rejectedValue);
+
+                ErrorResponse errorResponse = new ErrorResponse(
+                                "VALIDATION_ERROR",
+                                "Validation failed",
                                 details,
                                 Instant.now(),
                                 request.getRequestURI());

--- a/src/main/java/dev/codedbydavid/eventhub/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/codedbydavid/eventhub/presentation/exception/GlobalExceptionHandler.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.Instant;
+import java.time.temporal.TemporalAccessor;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -91,8 +93,7 @@ public class GlobalExceptionHandler {
                         MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
                 String parameterName = ex.getName();
                 Object rejectedValue = ex.getValue();
-                String details = "%s: invalid value '%s'. Expected ISO-8601 date-time (e.g., 2030-01-01T10:00:00Z)"
-                                .formatted(parameterName, rejectedValue);
+                String details = buildTypeMismatchDetails(parameterName, rejectedValue, ex.getRequiredType());
 
                 log.warn("Invalid request parameter for {} {}: {}={}",
                                 request.getMethod(),
@@ -108,6 +109,24 @@ public class GlobalExceptionHandler {
                                 request.getRequestURI());
 
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        }
+
+        private String buildTypeMismatchDetails(String parameterName, Object rejectedValue, Class<?> requiredType) {
+                if (requiredType != null) {
+                        if (TemporalAccessor.class.isAssignableFrom(requiredType)) {
+                                return "%s: invalid value '%s'. Expected ISO-8601 date-time (e.g., 2030-01-01T10:00:00Z)"
+                                                .formatted(parameterName, rejectedValue);
+                        }
+
+                        if (UUID.class.isAssignableFrom(requiredType)) {
+                                return "%s: invalid value '%s'. Expected UUID".formatted(parameterName, rejectedValue);
+                        }
+
+                        return "%s: invalid value '%s'. Expected %s"
+                                        .formatted(parameterName, rejectedValue, requiredType.getSimpleName());
+                }
+
+                return "%s: invalid value '%s'".formatted(parameterName, rejectedValue);
         }
 
         @ExceptionHandler(HttpMessageNotReadableException.class)


### PR DESCRIPTION
# Summary
Hardens the `GET /api/v1/events` read path so the list endpoint behaves more like a production-minded query API instead of a basic CRUD listing.

This PR introduces explicit default ordering by `startsAt`, adds optional `startsAt`-based filters for the events list, and tightens invalid query parameter handling with consistent API error responses. It also aligns Swagger/OpenAPI documentation with the supported query behavior and reinforces the contract with tests.

# Scope
- **Area:** Events / Query API / Validation / Docs
- **Type:** feat + fix + docs + tests
- **Related issue(s):** N/A

# Changes
## Architecture / Design
- Added explicit default ordering for `GET /api/v1/events` so results no longer depend on implicit database ordering.
- Extended the list use case with optional temporal filtering based on `startsAt`.
- Kept the existing response shape for the list endpoint; no pagination or contract-breaking refactor was introduced.
- Hardened query parameter validation and kept error handling aligned with the existing API error contract.
- Updated API documentation to describe the supported query parameters and their expected behavior.
- Kept the change scoped to the events listing flow across presentation / application / domain / infrastructure.

## API Contract (if applicable)
- **Endpoint(s):**
	- `GET /api/v1/events` → `200`
- **Behavior changes:**
	- The endpoint now returns events with an explicit default order based on `startsAt`.
	- The endpoint now supports optional `startsAt`-related filters for narrowing results.
	- Invalid query parameter values now return a consistent `400` response instead of relying on framework-default behavior.
	- The response body remains a JSON list; no pagination envelope or schema change was introduced.

## Validation & Error Handling (if applicable)
- **400** when:
	- list query parameters are malformed or cannot be parsed
	- a temporal filter combination is invalid
	- request parameters do not satisfy the endpoint contract
- **404** when:
	- N/A in this PR
- **409** when:
	- N/A in this PR

## Persistence / Data (if applicable)
- No persistence schema changes
- No Flyway migrations
- No new constraints or indexes
- Existing persistence/query flow was extended to support explicit ordering and optional temporal filtering

# Root Cause (if bugfix)
- **Observed:** `GET /api/v1/events` behaved like a basic unsorted list endpoint and did not provide a robust query contract for real client usage. Invalid query parameters were also not hardened enough as part of the public API contract.
- **Cause:** The initial implementation covered the basic CRUD read path, but list-query behavior, ordering guarantees, and malformed query handling had not yet been tightened as an interview-grade backend slice.
- **Fix:** Add explicit default sorting, introduce minimal optional temporal filters, and harden invalid query parameter handling while keeping the existing response contract stable.

# How to Test
## Local
1. `./gradlew bootRun`
2. Open: `http://localhost:8080/swagger-ui/index.html`
3. Steps:
	- Create several events with different `startsAt` values
	- Call `GET /api/v1/events` without query params and verify stable ordering by `startsAt`
	- Call `GET /api/v1/events` with supported temporal filters and verify the result set is narrowed correctly
	- Call `GET /api/v1/events` with malformed query params and verify a consistent `400` error payload
	- Review Swagger/OpenAPI and confirm the list query parameters are documented

## Automated Tests
- [ ] Unit:
	- Existing unit suite via `./gradlew test`
- [ ] Integration:
	- `./gradlew integrationTest`
	- Verify integration coverage for:
		- list default ordering
		- list filtering
		- invalid query parameter handling

# Screenshots (attach)
- [ ] `GET /api/v1/events` returning ordered results
- [ ] `GET /api/v1/events` with filters applied
- [ ] `GET /api/v1/events` returning `400` for malformed query params
- [ ] Swagger/OpenAPI showing documented list query parameters

# Definition of Done
- [ ] Endpoints respond with correct statuses (200/201/204 + 400/404; 409 only for real conflicts)
- [ ] Validation messages are clear and consistent
- [ ] Error payload format is consistent across the API
- [ ] Swagger/OpenAPI is accessible locally
- [ ] Clean layers: domain/application/infrastructure/presentation remain separated

# Notes / Follow-ups
- This PR intentionally keeps the list endpoint response shape unchanged.
- Pagination was intentionally not introduced to keep the scope small and the contract stable.
- Future backlog: evaluate whether pagination and richer sorting options are worth adding once the current query contract is fully stable.
- Future backlog: consider documenting query examples in the runbook or README if this endpoint becomes part of the main demo flow.